### PR TITLE
[CUSTCOM-117] - Servlet Test Run Against Wrong Version

### DIFF
--- a/servlet/security-clientcert-parent/.mvn/extentions.xml
+++ b/servlet/security-clientcert-parent/.mvn/extentions.xml
@@ -1,0 +1,11 @@
+
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+
+    <extension>
+        <groupId>fish.payara.maven.extensions</groupId>
+        <artifactId>regex-profile-activator</artifactId>
+        <version>0.5</version>
+    </extension>
+
+</extensions>

--- a/servlet/security-clientcert-parent/pom.xml
+++ b/servlet/security-clientcert-parent/pom.xml
@@ -8,11 +8,12 @@
     </parent>
     <artifactId>security-clientcert-parent</artifactId>
     <packaging>pom</packaging>
-    
+
+    <name>security-clientcert-parent</name>
+
     <modules>
         <module>security-clientcert</module>
         <module>security-clientcert-jce</module>
-        <module>security-clientcert-common-name</module>
     </modules>
 
     <build>
@@ -29,4 +30,20 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>5.192+</id>
+            <activation>
+                <property>
+                    <name>payara.version</name>
+                    <value>/4.*/</value>
+                </property>
+            </activation>
+            <modules>
+                <module>security-clientcert-common-name</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
A test for the secure servlet features on 5.192+ is being run on all versions, this PR moves it to a different profile