### PR TITLE
QACI-253 Excluded javax.el as it is not needed

### DIFF
--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>samples-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>ejb</artifactId>
     <packaging>pom</packaging>
 
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.javaee7</groupId>
             <artifactId>test-utils</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ejb/remote/vendor/payara-glassfish/pom.xml
+++ b/ejb/remote/vendor/payara-glassfish/pom.xml
@@ -17,16 +17,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.main.appclient</groupId>
-            <artifactId>gf-client</artifactId>
+            <groupId>org.glassfish.main.security</groupId>
+            <artifactId>security</artifactId>
             <version>${glassfish.client.version}</version>
-            <exclusions>
-                <!-- Excluded dependency, overlapping with our definitions. -->
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>javax.el</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/ejb/remote/vendor/payara-glassfish/pom.xml
+++ b/ejb/remote/vendor/payara-glassfish/pom.xml
@@ -12,8 +12,7 @@
 
     <groupId>org.javaee7.ejb.remote.vendor</groupId>
     <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    
+
     <name>Java EE 7 Sample: ejb - remote - vendor - Payara and GlassFish Remote EJB Provider</name>
 
     <dependencies>
@@ -21,6 +20,13 @@
             <groupId>org.glassfish.main.appclient</groupId>
             <artifactId>gf-client</artifactId>
             <version>${glassfish.client.version}</version>
+            <exclusions>
+                <!-- Excluded dependency, overlapping with our definitions. -->
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/ejb/remote/vendor/pom.xml
+++ b/ejb/remote/vendor/pom.xml
@@ -9,15 +9,15 @@
         <artifactId>ejb-remote</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>ejb-remote-vendor</artifactId>
     <packaging>pom</packaging>
-   
+
     <properties>
-    	<glassfish.client.version>5.0</glassfish.client.version>
+        <glassfish.client.version>5.0</glassfish.client.version>
         <java.min.version>1.7</java.min.version>
     </properties>
-    
+
     <name>Java EE 7 Sample: ejb - remote - vendor</name>
 
     <profiles>


### PR DESCRIPTION
- module's dependency declarations allows using snapshots

FIXME later: javaee7-samples have serious problems with dependencies, which are not managed properly. At this moment this is rather minimal fix targeting a single place where the issue escalated.