### PR TITLE
Revert QACI-389

### DIFF
--- a/batch/chunk-mapper/pom.xml
+++ b/batch/chunk-mapper/pom.xml
@@ -12,22 +12,4 @@
     <name>Java EE 7 Sample: batch - chunk-mapper</name>
     <description>Chunk Processing - Read, Process, Write in multiple Threads</description>
 
-    <profiles>
-        <profile>
-            <id>stable</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
-                        <configuration>
-                            <test>!BatchChunkMapperTest#testBatchChunkMapper</test>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
 </project>


### PR DESCRIPTION
Earlier changes to QACI-389 cause no tests to be executed. This causes error. Removing these earlier changes