### PR TITLE
[QACI-389] disable batch chunk mapper test

### DIFF
--- a/batch/chunk-mapper/pom.xml
+++ b/batch/chunk-mapper/pom.xml
@@ -12,4 +12,22 @@
     <name>Java EE 7 Sample: batch - chunk-mapper</name>
     <description>Chunk Processing - Read, Process, Write in multiple Threads</description>
 
+    <profiles>
+        <profile>
+            <id>stable</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <test>!org.javaee7.batch.sample.chunk.mapper.BatchChunkMapperTest#testBatchChunkMapper</test>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/batch/chunk-mapper/pom.xml
+++ b/batch/chunk-mapper/pom.xml
@@ -22,7 +22,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>3.0.0-M5</version>
                         <configuration>
-                            <test>!org.javaee7.batch.sample.chunk.mapper.BatchChunkMapperTest#testBatchChunkMapper</test>
+                            <excludes>
+                                <exclude>**/BatchChunkMapperTest</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/batch/chunk-mapper/pom.xml
+++ b/batch/chunk-mapper/pom.xml
@@ -23,7 +23,7 @@
                         <version>3.0.0-M5</version>
                         <configuration>
                             <excludes>
-                                <exclude>**/BatchChunkMapperTest</exclude>
+                                <exclude>**/BatchChunkMapperTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Excludes the entire class so there won't be tests expected to run and test will not fail sporadically