### PR TITLE
FISH-5873 InaccessibleObjectException in Websockets on JDK 17

### DIFF
--- a/websocket/endpoint-async/pom.xml
+++ b/websocket/endpoint-async/pom.xml
@@ -13,4 +13,24 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Java EE 7 Sample: websocket - endpoint-async</name>
+
+    <profiles>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
I suspect the InaccessibleObjectException is coming from cglib which is used by awaitility. Awaitility has an incompatibility with JDK17 and so I wasn't able to upgrade it. See the JIRA ticket comment for more information.

Until this is resolved upstream add-opens is put in place but only for this test as it's the only one impacted by this issue.

Tested on Windows 10, Server & Websocket Test Suite JDK8 and JDK17