### PR TITLE
FISH-6355: fixing issue to pass javaee7 samples

### DIFF
--- a/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/config/DataSourceDefinitionConfig.java
+++ b/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/config/DataSourceDefinitionConfig.java
@@ -6,7 +6,7 @@ import jakarta.ejb.Stateless;
 @DataSourceDefinition(
     name = "java:app/MyApp/MyDS",
     className = "org.h2.jdbcx.JdbcDataSource",
-    url = "jdbc:h2:mem:test;NON_KEYWORDS=VALUE")
+    url = "jdbc:h2:mem:test")
 @Stateless
 public class DataSourceDefinitionConfig {
 }

--- a/jpa/datasourcedefinition-applicationxml-pu/src/main/resources/application-ejb.xml
+++ b/jpa/datasourcedefinition-applicationxml-pu/src/main/resources/application-ejb.xml
@@ -16,7 +16,7 @@
     <data-source>
         <name>java:app/MyApp/MyDS</name>
         <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
-        <url>jdbc:h2:mem:test;NON_KEYWORDS=VALUE</url>
+        <url>jdbc:h2:mem:test</url>
     </data-source>
 
 </application>

--- a/jpa/datasourcedefinition-applicationxml-pu/src/main/resources/application-web.xml
+++ b/jpa/datasourcedefinition-applicationxml-pu/src/main/resources/application-web.xml
@@ -13,7 +13,7 @@
     <data-source>
         <name>java:app/MyApp/MyDS</name>
         <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
-        <url>jdbc:h2:mem:test;NON_KEYWORDS=VALUE</url>
+        <url>jdbc:h2:mem:test</url>
     </data-source>
 
 </application>

--- a/jpa/datasourcedefinition-webxml-pu/src/main/webapp/WEB-INF/web.xml
+++ b/jpa/datasourcedefinition-webxml-pu/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,7 @@
     <data-source>
         <name>java:app/MyApp/MyDS</name>
         <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
-        <url>jdbc:h2:mem:test;NON_KEYWORDS=VALUE</url>
+        <url>jdbc:h2:mem:test</url>
     </data-source>
 
 </web-app>


### PR DESCRIPTION
Fixing issue when creating JPA connections using unsupported property NON_KEYWORDS