### PR TITLE
Fish-6411: Make tests EE10-compatible

### DIFF
--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyChunkListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyChunkListener.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.chunk.listener.AbstractChunkListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyChunkListener extends AbstractChunkListener {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemProcessor.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemProcessorListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemProcessorListener.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.chunk.listener.AbstractItemProcessListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessorListener extends AbstractItemProcessListener {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemReadListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemReadListener.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.chunk.listener.AbstractItemReadListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReadListener extends AbstractItemReadListener {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemReader.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemReader.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.batch.listeners;
 
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private final StringTokenizer tokens;

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemWriteListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemWriteListener.java
@@ -42,12 +42,14 @@ package org.javaee7.batch.batch.listeners;
 
 import java.util.List;
 import jakarta.batch.api.chunk.listener.AbstractItemWriteListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriteListener extends AbstractItemWriteListener {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemWriter.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.batch.listeners;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyJobListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyJobListener.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.listener.AbstractJobListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyJobListener extends AbstractJobListener {
 
     @Override

--- a/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyStepListener.java
+++ b/batch/batch-listeners/src/main/java/org/javaee7/batch/batch/listeners/MyStepListener.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.batch.listeners;
 
 import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyStepListener extends AbstractStepListener {
 
     @Override

--- a/batch/batch-listeners/src/test/java/org/javaee7/batch/batch/listeners/BatchListenersTest.java
+++ b/batch/batch-listeners/src/test/java/org/javaee7/batch/batch/listeners/BatchListenersTest.java
@@ -100,7 +100,6 @@ public class BatchListenersTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.batch.listeners")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/batchlet-simple/src/main/java/org/javaee7/batch/batchlet/simple/MyBatchlet.java
+++ b/batch/batchlet-simple/src/main/java/org/javaee7/batch/batchlet/simple/MyBatchlet.java
@@ -43,12 +43,14 @@ import static java.lang.System.out;
 import static jakarta.batch.runtime.BatchStatus.COMPLETED;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet extends AbstractBatchlet {
     
     @Override

--- a/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
+++ b/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
@@ -2,9 +2,7 @@ package org.javaee7.batch.batchlet.simple;
 
 import static jakarta.batch.runtime.BatchRuntime.getJobOperator;
 import static jakarta.batch.runtime.BatchStatus.COMPLETED;
-import static org.jboss.shrinkwrap.api.ArchivePaths.create;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
@@ -59,7 +57,6 @@ public class MyBatchletTest {
         war = create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addClass(MyBatchlet.class)
-            .addAsWebInfResource(INSTANCE, create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         
         System.out.println(war.toString(true));

--- a/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyCheckpointAlgorithm.java
+++ b/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyCheckpointAlgorithm.java
@@ -43,12 +43,14 @@ package org.javaee7.batch.chunk.checkpoint;
 import java.util.concurrent.CountDownLatch;
 
 import jakarta.batch.api.chunk.AbstractCheckpointAlgorithm;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyCheckpointAlgorithm extends AbstractCheckpointAlgorithm {
     
     public static CountDownLatch checkpointCountDownLatch = new CountDownLatch(10);

--- a/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemProcessor.java
+++ b/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.chunk.checkpoint;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemReader.java
+++ b/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemReader.java
@@ -42,12 +42,14 @@ package org.javaee7.batch.chunk.checkpoint;
 import java.io.Serializable;
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private StringTokenizer tokens;

--- a/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemWriter.java
+++ b/batch/chunk-checkpoint/src/main/java/org/javaee7/batch/chunk/checkpoint/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.chunk.checkpoint;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/chunk-checkpoint/src/test/java/org/javaee7/batch/chunk/checkpoint/BatchChunkCheckpointTest.java
+++ b/batch/chunk-checkpoint/src/test/java/org/javaee7/batch/chunk/checkpoint/BatchChunkCheckpointTest.java
@@ -8,9 +8,7 @@ import static jakarta.batch.runtime.Metric.MetricType.READ_COUNT;
 import static jakarta.batch.runtime.Metric.MetricType.WRITE_COUNT;
 import static org.javaee7.batch.chunk.checkpoint.MyCheckpointAlgorithm.checkpointCountDownLatch;
 import static org.javaee7.util.BatchTestHelper.getMetricsMap;
-import static org.jboss.shrinkwrap.api.ArchivePaths.create;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -72,7 +70,6 @@ public class BatchChunkCheckpointTest {
         WebArchive war = create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.chunk.checkpoint")
-            .addAsWebInfResource(INSTANCE, create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         
         System.out.println("\nBatchChunkCheckpointTest test war content: \n" + war.toString(true) + "\n");

--- a/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemProcessor.java
+++ b/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemProcessor.java
@@ -43,12 +43,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
     private static int id = 1;
     private SimpleDateFormat format = new SimpleDateFormat("M/dd/yy");

--- a/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemReader.java
+++ b/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemReader.java
@@ -46,12 +46,14 @@ import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private BufferedReader reader;

--- a/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemWriter.java
+++ b/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemWriter.java
@@ -41,6 +41,7 @@ package org.javaee7.batch.chunk.csv.database;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -49,6 +50,7 @@ import jakarta.persistence.PersistenceContext;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @PersistenceContext

--- a/batch/chunk-csv-database/src/main/resources/META-INF/persistence.xml
+++ b/batch/chunk-csv-database/src/main/resources/META-INF/persistence.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence 
     version="2.1" 
-    xmlns="http://xmlns.jcp.org/xml/ns/persistence" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence">
     <persistence-unit name="MyPU" transaction-type="JTA">
         <properties>
             <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>

--- a/batch/chunk-csv-database/src/test/java/org/javaee7/batch/chunk/csv/database/BatchCSVDatabaseTest.java
+++ b/batch/chunk-csv-database/src/test/java/org/javaee7/batch/chunk/csv/database/BatchCSVDatabaseTest.java
@@ -78,7 +78,6 @@ public class BatchCSVDatabaseTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.chunk.csv.database")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml")
             .addAsResource("META-INF/persistence.xml")
             .addAsResource("META-INF/create.sql")

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemProcessor.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemReader.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemReader.java
@@ -40,6 +40,7 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import java.io.Serializable;
 import java.util.StringTokenizer;
@@ -48,6 +49,7 @@ import java.util.StringTokenizer;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private StringTokenizer tokens;

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemWriter.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyItemWriter.java
@@ -40,6 +40,7 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import java.util.List;
 
@@ -47,6 +48,7 @@ import java.util.List;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
     private static int retries = 0;
 

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryProcessorListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryProcessorListener.java
@@ -1,12 +1,14 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.RetryProcessListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Roberto Cortez
  */
 @Named
+@Dependent
 public class MyRetryProcessorListener implements RetryProcessListener {
     @Override
     public void onRetryProcessException(Object item, Exception ex) throws Exception {

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryReadListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryReadListener.java
@@ -1,12 +1,14 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.RetryReadListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Roberto Cortez
  */
 @Named
+@Dependent
 public class MyRetryReadListener implements RetryReadListener {
     @Override
     public void onRetryReadException(Exception ex) throws Exception {

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryWriteListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MyRetryWriteListener.java
@@ -1,6 +1,7 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.RetryWriteListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import java.util.List;
  * @author Roberto Cortez
  */
 @Named
+@Dependent
 public class MyRetryWriteListener implements RetryWriteListener {
     @Override
     public void onRetryWriteException(List<Object> items, Exception ex) throws Exception {

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipProcessorListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipProcessorListener.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.SkipProcessListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MySkipProcessorListener implements SkipProcessListener {
     @Override
     public void onSkipProcessItem(Object t, Exception e) throws Exception {

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipReadListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipReadListener.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.SkipReadListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MySkipReadListener implements SkipReadListener {
     @Override
     public void onSkipReadItem(Exception e) throws Exception {

--- a/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipWriteListener.java
+++ b/batch/chunk-exception/src/main/java/org/javaee7/batch/chunk/exception/MySkipWriteListener.java
@@ -40,6 +40,7 @@
 package org.javaee7.batch.chunk.exception;
 
 import jakarta.batch.api.chunk.listener.SkipWriteListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import java.util.List;
 
@@ -47,6 +48,7 @@ import java.util.List;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MySkipWriteListener implements SkipWriteListener {
     @Override
     public void onSkipWriteItem(List list, Exception e) throws Exception {

--- a/batch/chunk-exception/src/test/java/org/javaee7/batch/chunk/exception/BatchChunkExceptionTest.java
+++ b/batch/chunk-exception/src/test/java/org/javaee7/batch/chunk/exception/BatchChunkExceptionTest.java
@@ -105,7 +105,6 @@ public class BatchChunkExceptionTest {
         WebArchive war = create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.chunk.exception")
-            .addAsWebInfResource(INSTANCE, create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         
         System.out.println("\nContent of test war for BatchChunkExceptionTest \n " + war.toString(true) + "\n");

--- a/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemProcessor.java
+++ b/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.sample.chunk.mapper;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemReader.java
+++ b/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemReader.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.batch.api.BatchProperty;
 import jakarta.batch.api.chunk.AbstractItemReader;
 import jakarta.batch.runtime.context.JobContext;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -52,6 +53,7 @@ import jakarta.inject.Named;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
     static AtomicInteger totalReaders = new AtomicInteger();
     private int readerId;

--- a/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemWriter.java
+++ b/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.sample.chunk.mapper;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyMapper.java
+++ b/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyMapper.java
@@ -43,12 +43,14 @@ import java.util.Properties;
 import jakarta.batch.api.partition.PartitionMapper;
 import jakarta.batch.api.partition.PartitionPlan;
 import jakarta.batch.api.partition.PartitionPlanImpl;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyMapper implements PartitionMapper {
 
     @Override

--- a/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyReducer.java
+++ b/batch/chunk-mapper/src/main/java/org/javaee7/batch/sample/chunk/mapper/MyReducer.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.sample.chunk.mapper;
 
 import jakarta.batch.api.partition.PartitionReducer;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyReducer implements PartitionReducer {
 
     @Override

--- a/batch/chunk-mapper/src/test/java/org/javaee7/batch/sample/chunk/mapper/BatchChunkMapperTest.java
+++ b/batch/chunk-mapper/src/test/java/org/javaee7/batch/sample/chunk/mapper/BatchChunkMapperTest.java
@@ -84,7 +84,6 @@ public class BatchChunkMapperTest {
         WebArchive war = create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.sample.chunk.mapper")
-            .addAsWebInfResource(INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml")
             .addAsLibraries(awaitability());
 

--- a/batch/chunk-optional-processor/src/main/java/org/javaee7/batch/chunk/optional/processor/MyItemReader.java
+++ b/batch/chunk-optional-processor/src/main/java/org/javaee7/batch/chunk/optional/processor/MyItemReader.java
@@ -44,12 +44,14 @@ package org.javaee7.batch.chunk.optional.processor;
 import java.io.Serializable;
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private StringTokenizer tokens;

--- a/batch/chunk-optional-processor/src/main/java/org/javaee7/batch/chunk/optional/processor/MyItemWriter.java
+++ b/batch/chunk-optional-processor/src/main/java/org/javaee7/batch/chunk/optional/processor/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.chunk.optional.processor;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/chunk-optional-processor/src/test/java/org/javaee7/batch/chunk/optional/processor/BatchChunkOptionalProcessorTest.java
+++ b/batch/chunk-optional-processor/src/test/java/org/javaee7/batch/chunk/optional/processor/BatchChunkOptionalProcessorTest.java
@@ -53,7 +53,6 @@ public class BatchChunkOptionalProcessorTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.chunk.optional.processor")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemProcessor.java
+++ b/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemProcessor.java
@@ -41,6 +41,7 @@ package org.javaee7.batch.sample.chunk.partition;
 
 import jakarta.batch.api.chunk.ItemProcessor;
 import jakarta.batch.runtime.context.JobContext;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
@@ -48,6 +49,7 @@ import jakarta.inject.Named;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
     public static int totalProcessors = 0;
     private int processorId;

--- a/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemReader.java
+++ b/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemReader.java
@@ -41,6 +41,7 @@ package org.javaee7.batch.sample.chunk.partition;
 
 import jakarta.batch.api.BatchProperty;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import java.io.Serializable;
@@ -50,6 +51,7 @@ import java.util.StringTokenizer;
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
     public static int totalReaders = 0;
     private int readerId;

--- a/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemWriter.java
+++ b/batch/chunk-partition/src/main/java/org/javaee7/batch/sample/chunk/partition/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.sample.chunk.partition;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/chunk-partition/src/test/java/org/javaee7/batch/sample/chunk/partition/BatchChunkPartitionTest.java
+++ b/batch/chunk-partition/src/test/java/org/javaee7/batch/sample/chunk/partition/BatchChunkPartitionTest.java
@@ -70,7 +70,6 @@ public class BatchChunkPartitionTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.sample.chunk.partition")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemProcessor.java
+++ b/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.chunk.simple;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemReader.java
+++ b/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemReader.java
@@ -42,12 +42,14 @@ package org.javaee7.batch.chunk.simple;
 import java.io.Serializable;
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private StringTokenizer tokens;

--- a/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemWriter.java
+++ b/batch/chunk-simple/src/main/java/org/javaee7/batch/chunk/simple/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.chunk.simple;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
+++ b/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
@@ -52,7 +52,6 @@ public class ChunkSimpleTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.chunk.simple")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet1.java
+++ b/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet1.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.decision;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet1 extends AbstractBatchlet {
 
     @Override

--- a/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet2.java
+++ b/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet2.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.decision;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet2 extends AbstractBatchlet {
 
     @Override

--- a/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet3.java
+++ b/batch/decision/src/main/java/org/javaee7/batch/decision/MyBatchlet3.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.decision;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet3 extends AbstractBatchlet {
 
     @Override

--- a/batch/decision/src/main/java/org/javaee7/batch/decision/MyDecider.java
+++ b/batch/decision/src/main/java/org/javaee7/batch/decision/MyDecider.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.decision;
 
 import jakarta.batch.api.Decider;
 import jakarta.batch.runtime.StepExecution;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyDecider implements Decider {
 
     @Override

--- a/batch/decision/src/test/java/org/javaee7/batch/decision/BatchDecisionTest.java
+++ b/batch/decision/src/test/java/org/javaee7/batch/decision/BatchDecisionTest.java
@@ -57,7 +57,6 @@ public class BatchDecisionTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.decision")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/flow/src/main/java/org/javaee7/batch/flow/MyBatchlet1.java
+++ b/batch/flow/src/main/java/org/javaee7/batch/flow/MyBatchlet1.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.flow;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet1 extends AbstractBatchlet {
 
     @Override

--- a/batch/flow/src/main/java/org/javaee7/batch/flow/MyBatchlet2.java
+++ b/batch/flow/src/main/java/org/javaee7/batch/flow/MyBatchlet2.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.flow;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet2 extends AbstractBatchlet {
 
     @Override

--- a/batch/flow/src/main/java/org/javaee7/batch/flow/MyItemReader.java
+++ b/batch/flow/src/main/java/org/javaee7/batch/flow/MyItemReader.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.flow;
 
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemReader extends AbstractItemReader {
 
     private final StringTokenizer tokens;

--- a/batch/flow/src/main/java/org/javaee7/batch/flow/MyItemWriter.java
+++ b/batch/flow/src/main/java/org/javaee7/batch/flow/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.flow;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/flow/src/test/java/org/javaee7/batch/flow/BatchFlowTest.java
+++ b/batch/flow/src/test/java/org/javaee7/batch/flow/BatchFlowTest.java
@@ -55,7 +55,6 @@ public class BatchFlowTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.flow")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyBatchlet.java
+++ b/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyBatchlet.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.multiple.steps;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet extends AbstractBatchlet {
 
     @Override

--- a/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemProcessor.java
+++ b/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemProcessor.java
@@ -40,12 +40,14 @@
 package org.javaee7.batch.multiple.steps;
 
 import jakarta.batch.api.chunk.ItemProcessor;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemProcessor implements ItemProcessor {
 
     @Override

--- a/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemReader.java
+++ b/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemReader.java
@@ -41,12 +41,15 @@ package org.javaee7.batch.multiple.steps;
 
 import java.util.StringTokenizer;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
+
 public class MyItemReader extends AbstractItemReader {
 
     private final StringTokenizer tokens;

--- a/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemWriter.java
+++ b/batch/multiple-steps/src/main/java/org/javaee7/batch/multiple/steps/MyItemWriter.java
@@ -41,12 +41,14 @@ package org.javaee7.batch.multiple.steps;
 
 import java.util.List;
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyItemWriter extends AbstractItemWriter {
 
     @Override

--- a/batch/multiple-steps/src/test/java/org/javaee7/batch/multiple/steps/BatchMultipleStepsTest.java
+++ b/batch/multiple-steps/src/test/java/org/javaee7/batch/multiple/steps/BatchMultipleStepsTest.java
@@ -53,7 +53,6 @@ public class BatchMultipleStepsTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.multiple.steps")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/batch/scheduling/src/main/java/org/javaee7/batch/samples/scheduling/MyBatchlet.java
+++ b/batch/scheduling/src/main/java/org/javaee7/batch/samples/scheduling/MyBatchlet.java
@@ -3,12 +3,14 @@ package org.javaee7.batch.samples.scheduling;
 import static jakarta.batch.runtime.BatchStatus.COMPLETED;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Roberto Cortez
  */
 @Named
+@Dependent
 public class MyBatchlet extends AbstractBatchlet {
     
     @Override

--- a/batch/scheduling/src/test/java/org/javaee7/batch/samples/scheduling/MyStepListener.java
+++ b/batch/scheduling/src/test/java/org/javaee7/batch/samples/scheduling/MyStepListener.java
@@ -3,9 +3,11 @@ package org.javaee7.batch.samples.scheduling;
 import java.util.concurrent.CountDownLatch;
 
 import jakarta.batch.api.listener.AbstractStepListener;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 @Named
+@Dependent
 public class MyStepListener extends AbstractStepListener {
     
     public static CountDownLatch countDownLatch = new CountDownLatch(3);

--- a/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet1.java
+++ b/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet1.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.split;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet1 extends AbstractBatchlet {
 
     @Override

--- a/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet2.java
+++ b/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet2.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.split;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet2 extends AbstractBatchlet {
 
     @Override

--- a/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet3.java
+++ b/batch/split/src/main/java/org/javaee7/batch/split/MyBatchlet3.java
@@ -41,12 +41,14 @@
 package org.javaee7.batch.split;
 
 import jakarta.batch.api.AbstractBatchlet;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
 @Named
+@Dependent
 public class MyBatchlet3 extends AbstractBatchlet {
 
     @Override

--- a/batch/split/src/test/java/org/javaee7/batch/split/BatchSplitTest.java
+++ b/batch/split/src/test/java/org/javaee7/batch/split/BatchSplitTest.java
@@ -55,7 +55,6 @@ public class BatchSplitTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
             .addClass(BatchTestHelper.class)
             .addPackage("org.javaee7.batch.split")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addAsResource("META-INF/batch-jobs/myJob.xml");
         System.out.println(war.toString(true));
         return war;

--- a/cdi/beansxml-noversion/src/test/java/org/javaee7/cdi/beansxml/noversion/GreetingTest.java
+++ b/cdi/beansxml-noversion/src/test/java/org/javaee7/cdi/beansxml/noversion/GreetingTest.java
@@ -9,9 +9,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+import jakarta.enterprise.inject.Instance;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -29,13 +31,13 @@ public class GreetingTest {
     @Inject
     AnnotatedBean annotatedBean;
     @Inject
-    NotAnnotatedBean notAnnotatedBean;
+    Instance<NotAnnotatedBean> notAnnotatedBean;
 
     @Test
     public void should_bean_be_injected() throws Exception {
         assertThat(annotatedBean, is(notNullValue()));
 
-        // notAnnotatedBean is injected because CDI acts as version 1.0 if version is not explicit
-        assertThat(notAnnotatedBean, is(notNullValue()));
+        // notAnnotatedBean is not injected because CDI 4.0 acts as the mode was annotated
+        assertFalse(notAnnotatedBean.isResolvable());
     }
 }

--- a/concurrency/managedexecutor/src/main/java/org/javaee7/concurrency/managedexecutor/MyTaskWithTransaction.java
+++ b/concurrency/managedexecutor/src/main/java/org/javaee7/concurrency/managedexecutor/MyTaskWithTransaction.java
@@ -39,6 +39,7 @@
  */
 package org.javaee7.concurrency.managedexecutor;
 
+import jakarta.enterprise.context.Dependent;
 import java.util.Objects;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -46,6 +47,7 @@ import jakarta.transaction.Transactional;
 /**
  * @author Arun Gupta
  */
+@Dependent
 public class MyTaskWithTransaction implements Runnable {
 
     private int id;

--- a/concurrency/managedexecutor/src/test/java/org/javaee7/concurrency/managedexecutor/ExecutorInjectTest.java
+++ b/concurrency/managedexecutor/src/test/java/org/javaee7/concurrency/managedexecutor/ExecutorInjectTest.java
@@ -68,8 +68,7 @@ public class ExecutorInjectTest {
                 MyTaskWithTransaction.class,
                 MyTransactionScopedBean.class,
                 TestBean.class).
-            setWebXML(new FileAsset(new File("src/main/webapp/WEB-INF/web.xml"))).
-            addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml"); // Adding beans.xml shouldn't be required? WildFly Beta1
+            setWebXML(new FileAsset(new File("src/main/webapp/WEB-INF/web.xml")));
     }
 
     @Before

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthContext.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthContext.java
@@ -27,7 +27,7 @@ public class TestServerAuthContext implements ServerAuthContext {
 
     public TestServerAuthContext(CallbackHandler handler, ServerAuthModule serverAuthModule) throws AuthException {
         this.serverAuthModule = serverAuthModule;
-        serverAuthModule.initialize(null, null, handler, Collections.<String, String> emptyMap());
+        serverAuthModule.initialize(null, null, handler, Collections.<String, Object> emptyMap());
     }
 
     @Override

--- a/jaxws/jaxws-client/pom.xml
+++ b/jaxws/jaxws-client/pom.xml
@@ -52,7 +52,7 @@
                             
                             <verbose>true</verbose>
                             <sourceDestDir>${basedir}/src/main/java</sourceDestDir>
-                            <target>2.1</target>
+                            <target>3.0</target>
                         </configuration>
                     </execution>
                 </executions>

--- a/jca/mdb-filewatcher/src/test/java/org/javaee7/jca/filewatch/FileWatcherTest.java
+++ b/jca/mdb-filewatcher/src/test/java/org/javaee7/jca/filewatch/FileWatcherTest.java
@@ -19,6 +19,7 @@ package org.javaee7.jca.filewatch;
 import static com.jayway.awaitility.Awaitility.await;
 import static com.jayway.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
 import static com.jayway.awaitility.Duration.ONE_MINUTE;
+import jakarta.enterprise.context.Dependent;
 import static java.lang.System.out;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.javaee7.jca.filewatch.event.FileEvent.Type.CREATED;
@@ -52,6 +53,7 @@ import org.junit.runner.RunWith;
  * @author Bartosz Majsak (bartosz.majsak@gmail.com)
  */
 @RunWith(Arquillian.class)
+@Dependent
 public class FileWatcherTest {
 
     @Deployment
@@ -70,13 +72,11 @@ public class FileWatcherTest {
                     .addClasses(FileWatchingMDB.class)
                     // appropriate descriptor will be only picked up by the target container
                     .addAsManifestResource("glassfish-ejb-jar.xml")
-                    .addAsManifestResource("jboss-ejb3.xml")
-                    .addAsManifestResource(INSTANCE, "beans.xml"))
+                    .addAsManifestResource("jboss-ejb3.xml"))
             
             .addAsLibrary( 
                 create(JavaArchive.class, "test.jar")
-                    .addClasses(FileWatcherTest.class, FileEvent.class)
-                    .addAsManifestResource(INSTANCE, "beans.xml"))
+                    .addClasses(FileWatcherTest.class, FileEvent.class))
             
             .addAsLibraries(
                 Maven.resolver()

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/JmsItemReader.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/JmsItemReader.java
@@ -2,6 +2,7 @@ package org.javaee7.jms.batch;
 
 import jakarta.annotation.Resource;
 import jakarta.batch.api.chunk.AbstractItemReader;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Named;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSConsumer;
@@ -13,6 +14,7 @@ import java.io.Serializable;
  * @author Patrik Dudits
  */
 @Named
+@Dependent
 public class JmsItemReader extends AbstractItemReader {
 
     @Resource(lookup = Resources.CONNECTION_FACTORY)

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SummingItemWriter.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SummingItemWriter.java
@@ -1,6 +1,7 @@
 package org.javaee7.jms.batch;
 
 import jakarta.batch.api.chunk.AbstractItemWriter;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import java.io.Serializable;
@@ -10,6 +11,7 @@ import java.util.List;
  * @author Patrik Dudits
  */
 @Named
+@Dependent
 public class SummingItemWriter extends AbstractItemWriter {
     @Inject
     ResultCollector collector;

--- a/jms/jms-batch/src/test/java/org/javaee7/jms/batch/JmsItemReaderTest.java
+++ b/jms/jms-batch/src/test/java/org/javaee7/jms/batch/JmsItemReaderTest.java
@@ -54,7 +54,6 @@ public class JmsItemReaderTest {
     @Deployment
     public static WebArchive deployment() {
         return ShrinkWrap.create(WebArchive.class)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
             .addClass(BatchTestHelper.class)
             .addPackage(JmsItemReader.class.getPackage())
             .addAsResource("META-INF/batch-jobs/jms-job.xml");

--- a/jms/jms-xa/src/test/java/org/javaee7/jms/xa/producers/NonXAConnectionFactoryProducer.java
+++ b/jms/jms-xa/src/test/java/org/javaee7/jms/xa/producers/NonXAConnectionFactoryProducer.java
@@ -1,9 +1,11 @@
 package org.javaee7.jms.xa.producers;
 
 import jakarta.annotation.Resource;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.jms.ConnectionFactory;
 
+@Dependent
 public class NonXAConnectionFactoryProducer {
 
     @Produces

--- a/jms/jms-xa/src/test/java/org/javaee7/jms/xa/producers/XAConnectionFactoryProducer.java
+++ b/jms/jms-xa/src/test/java/org/javaee7/jms/xa/producers/XAConnectionFactoryProducer.java
@@ -1,9 +1,11 @@
 package org.javaee7.jms.xa.producers;
 
 import jakarta.annotation.Resource;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.jms.ConnectionFactory;
 
+@Dependent
 public class XAConnectionFactoryProducer {
 
     @Produces

--- a/jms/jms-xa/src/test/java/org/javaee7/jms/xa/utils/AbstractUserManagerTest.java
+++ b/jms/jms-xa/src/test/java/org/javaee7/jms/xa/utils/AbstractUserManagerTest.java
@@ -2,7 +2,6 @@ package org.javaee7.jms.xa.utils;
 
 import static org.javaee7.jms.xa.DeliveryStats.countDownLatch;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
 import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.CountDownLatch;
@@ -27,7 +26,6 @@ public class AbstractUserManagerTest {
 
     protected static WebArchive createWebArchive() {
         return create(WebArchive.class)
-                .addAsWebInfResource(INSTANCE, "beans.xml")
                 .addAsResource("META-INF/persistence.xml")
                 .addAsResource("META-INF/load.sql")
                 .addClass(AbstractUserManagerTest.class)

--- a/jpa/pu-typesafe/src/main/java/org/javaee7/jpa/pu/typesafe/ProducerBean.java
+++ b/jpa/pu-typesafe/src/main/java/org/javaee7/jpa/pu/typesafe/ProducerBean.java
@@ -39,7 +39,7 @@
  */
 package org.javaee7.jpa.pu.typesafe;
 
-import jakarta.annotation.ManagedBean;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -47,7 +47,7 @@ import jakarta.persistence.PersistenceContext;
 /**
  * @author Arun Gupta
  */
-@ManagedBean
+@Dependent
 public class ProducerBean {
     @Produces
     @PersistenceContext(unitName = "defaultPU")

--- a/jsf/ajax/src/test/java/org/javaee7/jsf/ajax/AjaxScriptTest.java
+++ b/jsf/ajax/src/test/java/org/javaee7/jsf/ajax/AjaxScriptTest.java
@@ -55,7 +55,7 @@ public class AjaxScriptTest {
         final String webappDirectory = "src/main/webapp";
         final String webInfDirectory = webappDirectory + "/WEB-INF";
         return ShrinkWrap.create(WebArchive.class)
-//            .addClass(User.class)
+            .addClass(EmptyValues.class)
             .addAsWebResource(new File(webappDirectory, "index.xhtml"))
             .addAsWebInfResource(new File(webInfDirectory, "web.xml"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             Application Server versions
             (these are downloaded and installed in these versions by Maven for the CI profiles)
          -->
-        <payara.version>6.2022.1.Alpha4-SNAPSHOT</payara.version>
+        <payara.version>6.2022.1.Alpha5-SNAPSHOT</payara.version>
         <payara_domain>domain1</payara_domain>
         <glassfish.client.version>5.0</glassfish.client.version> <!-- For remote EJB for Payara and Glassfish -->
         <glassfish.version>4.1.1</glassfish.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <name>Java EE 7 Sample: javaee7-samples</name>
 
     <properties>
-        <arquillian.version>1.7.0.Alpha9</arquillian.version>
-        <java.min.version>1.8</java.min.version>
+        <arquillian.version>1.7.0.Alpha12</arquillian.version>
+        <java.min.version>11</java.min.version>
         <maven.min.version>3.6.0</maven.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -49,7 +49,7 @@
             Application Server versions
             (these are downloaded and installed in these versions by Maven for the CI profiles)
          -->
-        <payara.version>6.2022.1.Alpha3-SNAPSHOT</payara.version>
+        <payara.version>6.2022.1.Alpha4-SNAPSHOT</payara.version>
         <payara_domain>domain1</payara_domain>
         <glassfish.client.version>5.0</glassfish.client.version> <!-- For remote EJB for Payara and Glassfish -->
         <glassfish.version>4.1.1</glassfish.version>
@@ -59,7 +59,7 @@
         <tomee.version>7.0.2</tomee.version>
         <tomcat.version>9.0.4</tomcat.version>
 
-        <payara.arquillian.version>3.0.alpha1</payara.arquillian.version>
+        <payara.arquillian.version>3.0.alpha4</payara.arquillian.version>
     </properties>
 
     <prerequisites>
@@ -154,15 +154,16 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>fish.payara.api</groupId>
+                <artifactId>payara-bom</artifactId>
+                <version>${payara.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>2.1.212</version>
-            </dependency>
-            <dependency>
-                <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee9</artifactId>
-                <version>${payara.arquillian.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.javaee7</groupId>
@@ -197,7 +198,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0-RC1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -645,11 +645,6 @@
             <id>payara-server-remote</id>
 
             <dependencies>
-                <!-- Java EE based client dependencies to contact a server via WebSocket or REST -->
-                <dependency>
-                    <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>payara-client-ee9</artifactId>
-                </dependency>
 
                 <!-- The actual Arquillian connector -->
                 <dependency>

--- a/validation/methods/src/main/java/org/javaee7/validation/methods/MyParameter.java
+++ b/validation/methods/src/main/java/org/javaee7/validation/methods/MyParameter.java
@@ -1,7 +1,9 @@
 package org.javaee7.validation.methods;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.validation.constraints.NotNull;
 
+@Dependent
 public class MyParameter {
 
     @NotNull

--- a/validation/methods/src/test/java/org/javaee7/validation/methods/ConstructorParametersConstraintsTest.java
+++ b/validation/methods/src/test/java/org/javaee7/validation/methods/ConstructorParametersConstraintsTest.java
@@ -36,8 +36,7 @@ public class ConstructorParametersConstraintsTest {
     @Deployment
     public static Archive<?> deployment() {
         return ShrinkWrap.create(JavaArchive.class)
-            .addClasses(MyBean2.class, MyParameter.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(MyBean2.class, MyParameter.class);
     }
 
     @Test

--- a/validation/methods/src/test/java/org/javaee7/validation/methods/ConstructorParametersInjectionTest.java
+++ b/validation/methods/src/test/java/org/javaee7/validation/methods/ConstructorParametersInjectionTest.java
@@ -29,8 +29,7 @@ public class ConstructorParametersInjectionTest {
     @Deployment
     public static Archive<?> deployment() {
         return ShrinkWrap.create(JavaArchive.class)
-            .addClasses(MyBean2.class, MyParameter.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(MyBean2.class, MyParameter.class);
     }
 
     @Test

--- a/validation/methods/src/test/java/org/javaee7/validation/methods/MethodParametersConstraintsTest.java
+++ b/validation/methods/src/test/java/org/javaee7/validation/methods/MethodParametersConstraintsTest.java
@@ -34,8 +34,7 @@ public class MethodParametersConstraintsTest {
 
     @Deployment
     public static Archive<?> deployment() {
-        return ShrinkWrap.create(JavaArchive.class).addClasses(MyBean.class)
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(JavaArchive.class).addClasses(MyBean.class);
     }
 
     @Test

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -56,6 +56,12 @@
     </build>
 
     <dependencies>
+        <!-- websocket test run as client and therefore need client-side Java SE impl -->
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-container-grizzly-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.javaee7</groupId>
             <artifactId>test-utils</artifactId>


### PR DESCRIPTION
* Do not rely on bean-discovery=all in CDI tests
* Adapt to some API changes
* Explicitly bring in websocket client rather than using client from arquillian connector