### PR TITLE
Fish 6736 Remove Links to Vendor Project

### DIFF
--- a/ejb/remote/roles-allowed-ssl/pom.xml
+++ b/ejb/remote/roles-allowed-ssl/pom.xml
@@ -12,40 +12,4 @@
 
     <name>Java EE 7 Sample: ejb - remote - Roles Allowed</name>
 
-    <profiles>
-        <profile>
-            <id>payara-server-managed</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>payara-server-remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>glassfish-remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
-
 </project>

--- a/ejb/remote/roles-allowed-ssl/pom.xml
+++ b/ejb/remote/roles-allowed-ssl/pom.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+  Copyright (c) 2018-2022 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/ejb/remote/roles-allowed/pom.xml
+++ b/ejb/remote/roles-allowed/pom.xml
@@ -1,5 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
+<!--
+  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+  Copyright (c) 2018-2022 Payara Foundation and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.javaee7</groupId>

--- a/ejb/remote/roles-allowed/pom.xml
+++ b/ejb/remote/roles-allowed/pom.xml
@@ -22,42 +22,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>payara-server-managed</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>payara-server-remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>glassfish-remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.javaee7.ejb.remote.vendor</groupId>
-                    <artifactId>ejb.remote.vendor.payara-glassfish</artifactId>
-                    <version>1.0-SNAPSHOT</version>
-                </dependency>
-            </dependencies>
-        </profile>
-
-    </profiles>
-
-
 </project>

--- a/jsf/viewscoped/src/main/java/org/javaee7/jsf/viewscoped/MyBean.java
+++ b/jsf/viewscoped/src/main/java/org/javaee7/jsf/viewscoped/MyBean.java
@@ -37,17 +37,18 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2022 Payara Foundation and/or its affiliates 
 package org.javaee7.jsf.viewscoped;
 
 import java.io.Serializable;
 
-import jakarta.faces.bean.ManagedBean;
 import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
 
 /**
  * @author Arun Gupta
  */
-@ManagedBean
+@Named
 @ViewScoped
 public class MyBean implements Serializable {
     private int value;


### PR DESCRIPTION
The vendor project was linked from pom files if two other projects.
Also, fixed source code using deprecated and removed ManagedBean, replaced with CDI bean.