### PR TITLE
FISH-8080 FISH-8081 Fix Secure Servlet tests

### DIFF
--- a/servlet/security-clientcert-parent/security-clientcert-jce/src/test/java/org/javaee7/servlet/security/clientcert/jce/SecureServletTest.java
+++ b/servlet/security-clientcert-parent/security-clientcert-jce/src/test/java/org/javaee7/servlet/security/clientcert/jce/SecureServletTest.java
@@ -5,8 +5,7 @@ import static java.math.BigInteger.ONE;
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.logging.Level.FINEST;
-import static org.javaee7.ServerOperations.addCertificateToContainerTrustStore;
-import static org.javaee7.ServerOperations.addContainerSystemProperty;
+import static org.javaee7.ServerOperations.*;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertTrue;
 import static org.omnifaces.utils.Lang.isEmpty;
@@ -132,6 +131,7 @@ public class SecureServletTest {
         
         // Only test TLS v1.2 for now
         System.setProperty("jdk.tls.client.protocols", "TLSv1.2");
+        disableTLSV13();
         
         // Enable to get detailed logging about the SSL handshake on the server
         

--- a/servlet/security-clientcert-parent/security-clientcert/src/test/java/org/javaee7/servlet/security/clientcert/SecureServletTest.java
+++ b/servlet/security-clientcert-parent/security-clientcert/src/test/java/org/javaee7/servlet/security/clientcert/SecureServletTest.java
@@ -1,33 +1,8 @@
 /** Copyright Payara Services Limited **/
 package org.javaee7.servlet.security.clientcert;
 
-import static java.math.BigInteger.ONE;
-import static java.time.Instant.now;
-import static java.time.temporal.ChronoUnit.DAYS;
-import static java.util.logging.Level.FINEST;
-import static org.javaee7.ServerOperations.addCertificateToContainerTrustStore;
-import static org.javaee7.ServerOperations.addContainerSystemProperty;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.junit.Assert.assertTrue;
-import static org.omnifaces.utils.Lang.isEmpty;
-import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
-import static org.omnifaces.utils.security.Certificates.createTempJKSTrustStore;
-import static org.omnifaces.utils.security.Certificates.generateRandomRSAKeys;
-import static org.omnifaces.utils.security.Certificates.getCertificateChainFromServer;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.security.KeyPair;
-import java.security.Provider;
-import java.security.Security;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.Date;
-import java.util.logging.Logger;
-
+import com.gargoylesoftware.htmlunit.TextPage;
+import com.gargoylesoftware.htmlunit.WebClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.impl.Jdk14Logger;
@@ -49,8 +24,28 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.omnifaces.utils.security.Certificates;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyPair;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.logging.Logger;
+
+import static java.math.BigInteger.ONE;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.logging.Level.FINEST;
+import static org.javaee7.ServerOperations.*;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertTrue;
+import static org.omnifaces.utils.Lang.isEmpty;
+import static org.omnifaces.utils.security.Certificates.*;
 
 /**
  * @author Arjan Tijms
@@ -73,6 +68,7 @@ public class SecureServletTest {
     public static WebArchive createDeployment() throws FileNotFoundException, IOException {
 
         System.out.println("\n*********** DEPLOYMENT START ***************************");
+        disableTLSV13();
         
         Security.addProvider(new BouncyCastleProvider());
 
@@ -263,5 +259,4 @@ public class SecureServletTest {
         ((Jdk14Logger) logger).getLogger().setLevel(FINEST);
         Logger.getGlobal().getParent().getHandlers()[0].setLevel(FINEST);
     }
-
 }

--- a/test-utils/src/main/java/org/javaee7/ServerOperations.java
+++ b/test-utils/src/main/java/org/javaee7/ServerOperations.java
@@ -98,7 +98,7 @@ public class ServerOperations {
                 logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara_domain to override.");
             }
 
-            Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.jks");
+            Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.p12");
 
             if (!cacertsPath.toFile().exists()) {
                 logger.severe("The container trust store at " + cacertsPath.toAbsolutePath() + " does not exists");
@@ -221,6 +221,14 @@ public class ServerOperations {
                 System.out.println(javaEEServer + " not supported");
             }
         }
+    }
+
+    public static void disableTLSV13() {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("set");
+        cmd.add("configs.config.server-config.network-config.protocols.protocol.http-listener-2.ssl.tls13-enabled=false");
+
+        CliCommands.payaraGlassFish(cmd);
     }
 
     public static void restartContainer() {

--- a/test-utils/src/main/java/org/javaee7/ServerOperations.java
+++ b/test-utils/src/main/java/org/javaee7/ServerOperations.java
@@ -110,7 +110,7 @@ public class ServerOperations {
 
             KeyStore keyStore = null;
             try (InputStream in = new FileInputStream(cacertsPath.toAbsolutePath().toFile())) {
-                keyStore = KeyStore.getInstance("JKS");
+                keyStore = KeyStore.getInstance("PKCS12");
                 keyStore.load(in, "changeit".toCharArray());
 
                 keyStore.setCertificateEntry("arquillianClientTestCert", clientCertificate);


### PR DESCRIPTION
Test fails due to using TLS1.3 - unsure how to make the test work on TLS 1.3 either. (no handshake failures or errors displayed in logs)