### PR TITLE
FISH-8721 - update glassfish version in ejb/remote/vendor to have an …

### DIFF
--- a/ejb/remote/vendor/pom.xml
+++ b/ejb/remote/vendor/pom.xml
@@ -41,6 +41,19 @@
                 <module>payara-glassfish</module>
             </modules>
         </profile>
+        
+        <profile>
+            <id>payara4</id>
+            <activation>
+                <property>
+                    <name>payara.version</name>
+                    <value>/4.*/</value>
+                </property>
+            </activation>
+            <properties>
+                <glassfish.client.version>4.0</glassfish.client.version>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/ejb/remote/vendor/pom.xml
+++ b/ejb/remote/vendor/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
    
     <properties>
-    	<glassfish.client.version>5.0</glassfish.client.version>
+    	<glassfish.client.version>5.0.1</glassfish.client.version>
         <java.min.version>1.7</java.min.version>
     </properties>
     


### PR DESCRIPTION
"Java EE 7 Sample: ejb - remote - vendor - Payara and GlassFish Remote EJB Provider" was failing with Payara 4 because gf-client relied on dependencies eventually requiring javax.transaction-api <1.2 now unavailable in maven repository. 
Updating the glassfish version, and gf-client, from 5.0 to 5.0.1, upgrades the dependencies to versions available to be downloaded during the test.
When using the profile Payara4, the glassfish version is set to 4.0.