### PR TITLE
FISH-11771: enforce Payara 6 instead of 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,8 +582,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^6.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 6"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>
@@ -740,8 +740,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^6.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 6"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>
@@ -812,8 +812,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^6.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 6"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>


### PR DESCRIPTION
An old regexp rule was preventing the run of the EE7 samples against Payara6. This PR fixes that.