### PR TITLE
FISH-11771: enforce Payara 7 instead of 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,8 +572,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^7.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 7"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>
@@ -730,8 +730,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^7.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 7"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>
@@ -802,8 +802,8 @@
                                 <requireProperty>
                                     <property>payara.version</property>
                                     <message>"Payara version must be specified."</message>
-                                    <regex>^5.*</regex>
-                                    <regexMessage>"This profile is only supported on Payara 5"</regexMessage>
+                                    <regex>^7.*</regex>
+                                    <regexMessage>"This profile is only supported on Payara 7"</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>


### PR DESCRIPTION
An old regexp rule was preventing the run of the EE7 samples against Payara7. This PR fixes that.
