### PR TITLE
FISH-11742: added javaEEServer to payara-server-managed profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,7 @@
                                 <payara.home>${session.executionRootDirectory}/target/${payara.directory.name}</payara.home>
                                 <arquillian.launch>payara${payara.version.major}</arquillian.launch>
                                 <payara_domain>${payara_domain}</payara_domain>
+                                <javaEEServer>payara-remote</javaEEServer>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
We are missing the javaEEServer environment variable from the payara-server-managed maven profile. This was causing some jaxrx tests to fail, as the asadmin commands were not correctly passed to install the users needed for the test.

See: https://github.com/payara/patched-src-javaee7-samples/blob/8580afd4ab763b4de3ab64b45bd7fce5b0eab3cb/test-utils/src/main/java/org/javaee7/ServerOperations.java#L44

Jenkins run: https://jenkins.payara.fish/job/FISH-11742-atomic-EE7-samples-runner-Development/67/