### PR TITLE
Fix Maven Warning

### DIFF
--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -30,18 +30,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-rt</artifactId>
-            <version>3.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-osgi</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
-            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -43,10 +42,6 @@
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.jws</groupId>


### PR DESCRIPTION
Fixes the "duplicate dependency" warning.

Also updates a dependency for EE 11 instead of using the EE 10 version