### PR TITLE
FISH-11675 Update JACC access method

### DIFF
--- a/jacc/pom.xml
+++ b/jacc/pom.xml
@@ -12,7 +12,7 @@
     <name>Java EE 7 Sample: jacc</name>
 
     <modules>
-        <!-- FISH-11628 Disabled temporarily
+        <!-- FISH-10721 Disabled temporarily
         <module>contexts</module>-->
         <module>permissions-xml</module>
     </modules>

--- a/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/jacc/JACC.java
+++ b/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/jacc/JACC.java
@@ -1,16 +1,12 @@
 package org.javaee7.jaspic.jaccpropagation.jacc;
 
-import static java.security.Policy.getPolicy;
 import static java.util.logging.Level.SEVERE;
 
-import java.security.CodeSource;
-import java.security.Principal;
-import java.security.ProtectionDomain;
-import java.security.cert.Certificate;
 import java.util.logging.Logger;
 
 import javax.security.auth.Subject;
 import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyFactory;
 import jakarta.security.jacc.WebResourcePermission;
 
 /**
@@ -33,13 +29,9 @@ public class JACC {
     }
 
     public static boolean hasAccess(String uri, Subject subject) {
-        return getPolicy().implies(
-            new ProtectionDomain(
-                new CodeSource(null, (Certificate[]) null), 
-                null, null,
-                subject.getPrincipals().toArray(new Principal[subject.getPrincipals().size()])
-            ),
-            new WebResourcePermission(uri, "GET")
-        );
+        return PolicyFactory
+                .getPolicyFactory()
+                .getPolicy()
+                .implies(new WebResourcePermission(uri, "GET"), subject);
     }
 }

--- a/jaspic/pom.xml
+++ b/jaspic/pom.xml
@@ -66,8 +66,7 @@
         <module>ejb-register-session</module>
 
         <!-- Tests that an established authenticated identity by JASPIC propagates correctly to a JACC provider -->
-        <!-- FISH-11628 Disabled temporarily
-        <module>jacc-propagation</module>-->
+        <module>jacc-propagation</module>
 
         <!-- Tests that a SAM is able to invoke EJB beans and CDI bean. NOTE; JASPIC 1.1 does not require this,
              although a JASPIC 1.1 compatible container "should" at least be able to call EJB beans (even though


### PR DESCRIPTION
With these changes:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.javaee7.jaspic.jaccpropagation.JACCPropagationPublicTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.241 s - in org.javaee7.jaspic.jaccpropagation.JACCPropagationPublicTest
[INFO] Running org.javaee7.jaspic.jaccpropagation.JACCPropagationProtectedTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.301 s - in org.javaee7.jaspic.jaccpropagation.JACCPropagationProtectedTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

I have reenabled the test and also updated the comment for jacc/contexts test as this is blocked by FISH-10721 once FISH-11672 is merged.